### PR TITLE
Fixed typos, syntax bugs and wrong file paths in Makefile for aplic(scalable)-imsic test

### DIFF
--- a/rtl/aplic/common/aplic_defines.svh
+++ b/rtl/aplic/common/aplic_defines.svh
@@ -5,5 +5,5 @@
 * Author: F.Marques <fmarques_00@protonmail.com>
 */ 
 
-// `define MSI_MODE
+//`define MSI_MODE
 `define DIRECT_MODE

--- a/rtl/aplic/common/axi4_lite_write_master.sv
+++ b/rtl/aplic/common/axi4_lite_write_master.sv
@@ -15,7 +15,7 @@ module axi_lite_write_master #(
     input logic                      clk_i  ,
     input logic                      rst_ni ,
     input logic                      ready_i,
-    input logic [3:0]                id_i,
+    //input logic [3:0]                id_i,
     output logic                     busy_o ,
     input logic [AXI_ADDR_WIDTH-1:0] addr_i ,
     input logic [AXI_DATA_WIDTH-1:0] data_i ,

--- a/rtl/aplic/common/axi4_lite_write_master.sv
+++ b/rtl/aplic/common/axi4_lite_write_master.sv
@@ -15,7 +15,6 @@ module axi_lite_write_master #(
     input logic                      clk_i  ,
     input logic                      rst_ni ,
     input logic                      ready_i,
-    //input logic [3:0]                id_i,
     output logic                     busy_o ,
     input logic [AXI_ADDR_WIDTH-1:0] addr_i ,
     input logic [AXI_DATA_WIDTH-1:0] data_i ,
@@ -85,99 +84,3 @@ module axi_lite_write_master #(
         end
     end
 endmodule
-
-
-// module axi_lite_write_master #(
-//     parameter int unsigned AXI_ADDR_WIDTH = 64,
-//     parameter int unsigned AXI_DATA_WIDTH = 64
-// ) (
-//     input logic                      clk_i  ,
-//     input logic                      rst_ni ,
-//     input logic                      ready_i,
-//     input logic [3:0]                id_i   ,
-//     output logic                     busy_o ,
-//     input logic [AXI_ADDR_WIDTH-1:0] addr_i ,
-//     input logic [AXI_DATA_WIDTH-1:0] data_i ,
-//     output ariane_axi::req_t         req_o  ,
-//     input ariane_axi::resp_t         resp_i
-// );
-
-//     typedef enum logic [1:0] {
-//         IDLE,
-//         AWAIT_AW,
-//         AWAIT_W,
-//         FINISH_TRANSACTION
-//     } state_t;
-
-//     logic[1:0] state_d, state_q;
-
-//     logic start_counter, timeout_counter;
-
-//     my_counter#(
-
-//     ) axi_counter_i (
-//         .clk_i          ( clk_i             ),
-//         .rst_ni         ( rst_ni            ),
-//         .start_i        ( start_counter     ),
-//         .stop_i         ( '0                ),
-//         .threshold_i    ( 2                 ),
-//         .timeout_o      ( timeout_counter   )
-//     );
-
-//     always_comb begin
-//     // Default values
-//     state_d         = state_q;
-//     start_counter   = '0;
-
-//     case (state_q)
-//       IDLE: begin
-//         busy_o              = '0;
-//         if (ready_i) begin
-//             busy_o          = 1'b1;
-//             state_d           = AWAIT_AW;
-//         end
-//       end
-//       AWAIT_AW: begin
-//         req_o.aw_valid      = '1;
-//         req_o.aw.addr       = 64'hC0000;
-//         start_counter       = '1;
-//         if (timeout_counter) begin
-//             req_o.aw.addr   = '0;
-//             busy_o          = 1'b1;
-//             req_o.w.strb    = '1;
-//             req_o.w_valid   = '1;
-//             req_o.w.last    = '1;
-//             req_o.w.data    = data_i;
-//             state_d         = AWAIT_W;  
-//         end
-//       end
-//       AWAIT_W:begin
-//           req_o.aw_valid  = '0;
-//           req_o.aw.addr       = 64'hC0000;
-//         if (resp_i.w_ready) begin
-//             busy_o          = 1'b1;
-//             req_o.w_valid   = '0;
-//             req_o.w.strb    = '1;
-//             req_o.w.last    = '1;
-//             state_d         = FINISH_TRANSACTION;
-//         end
-//       end
-//       FINISH_TRANSACTION:begin
-//           //validar b_valid?
-//           busy_o            = 1'b0;
-//           req_o.b_ready     = '1;
-//           state_d             = IDLE;
-//       end
-//     endcase
-//   end
-
-//   // Sequential logic for updating the state register
-//   always_ff @(posedge clk_i or negedge rst_ni) begin
-//     if (~rst_ni) begin
-//       state_q <= IDLE;
-//     end else begin
-//       state_q <= state_d;
-//     end
-//   end
-
-// endmodule

--- a/rtl/aplic/minimal/aplic_domain_notifier.sv
+++ b/rtl/aplic/minimal/aplic_domain_notifier.sv
@@ -29,10 +29,10 @@ module aplic_domain_notifier #(
     parameter int                                                   NR_IDCs         = 1,
     parameter int                                                   MIN_PRIO        = 6,
     // MSI mode parameters
-    parameter int unsigned                                          AXI_ADDR_WIDTH      = 64,
-    parameter int unsigned                                          AXI_DATA_WIDTH      = 64,
-    parameter unsigned                                              IMSIC_M_ADDR_TARGET = 64'h24000000,
-    parameter unsigned                                              IMSIC_S_ADDR_TARGET = 64'h28000000,
+    parameter int unsigned                                          AXI_ADDR_WIDTH  = 64,
+    parameter int unsigned                                          AXI_DATA_WIDTH  = 64,
+    parameter unsigned                                              IMSIC_M_ADDR_TARGET= 64'h24000000,
+    parameter unsigned                                              IMSIC_S_ADDR_TARGET= 64'h28000000,
     // DO NOT EDIT BY PARAMETER
     parameter int                                                   NR_BITS_SRC     = (NR_SRC > 32) ? 32 : NR_SRC,
     parameter int                                                   NR_REG          = (NR_SRC-1)/32,
@@ -128,7 +128,6 @@ localparam NR_IDC_W                 = (NR_IDCs == 1) ? 1 : $clog2(NR_IDCs);
     // signals from AXI 4 Lite
     logic [AXI_ADDR_WIDTH-1:0] addr_d, addr_q;
     logic [AXI_DATA_WIDTH-1:0] data_d, data_q;
-    logic [3:0]                id_i;
 
     logic                      axi_busy, axi_busy_q;
     logic [10:0]               intp_forwd_id_d, intp_forwd_id_q;
@@ -143,7 +142,6 @@ localparam NR_IDC_W                 = (NR_IDCs == 1) ? 1 : $clog2(NR_IDCs);
         genmsi_sent         = '0;
         data_d              = data_q;
         addr_d              = addr_q;
-        id_i                = '0;
 
         for (int i = 1 ; i < NR_SRC ; i++) begin
             /** If the interrupt is pending and enabled in its domain*/
@@ -152,7 +150,6 @@ localparam NR_IDC_W                 = (NR_IDCs == 1) ? 1 : $clog2(NR_IDCs);
                 data_d          = {{64-11{1'b0}}, i_target_q[i][10:0]};
                 addr_d          = (!i_intp_domain[i]) ? IMSIC_M_ADDR_TARGET :
                                   IMSIC_S_ADDR_TARGET + ({{64-32{1'b0}}, i_target_q[i]} & TARGET_GUEST_IDX_MASK) ;
-                id_i            = {3'b0, i_intp_domain[i]};
                 ready_i         = 1'b1;
                 forwarded_valid = 1'b1;
             end
@@ -165,7 +162,6 @@ localparam NR_IDC_W                 = (NR_IDCs == 1) ? 1 : $clog2(NR_IDCs);
                 data_d          = {32'b0, {21{1'b0}}, i_genmsi[i][10:0]};
                 addr_d          = (!i[0]) ? IMSIC_M_ADDR_TARGET :
                                   IMSIC_S_ADDR_TARGET + ({{64-32{1'b0}}, i_target_q[i]} & TARGET_GUEST_IDX_MASK) ;
-                id_i            = {3'b0, i[0]};
                 genmsi_sent[i]  = 1'b1;
                 ready_i         = 1'b1;
             end
@@ -186,7 +182,6 @@ localparam NR_IDC_W                 = (NR_IDCs == 1) ? 1 : $clog2(NR_IDCs);
         .clk_i          ( i_clk             ),
         .rst_ni         ( ni_rst            ),
         .ready_i        ( ready_i           ),
-        .id_i           ( id_i              ),
         .addr_i         ( addr_d            ),
         .data_i         ( data_d            ),
         .busy_o         ( axi_busy          ),

--- a/rtl/aplic/minimal/aplic_domain_notifier.sv
+++ b/rtl/aplic/minimal/aplic_domain_notifier.sv
@@ -29,10 +29,10 @@ module aplic_domain_notifier #(
     parameter int                                                   NR_IDCs         = 1,
     parameter int                                                   MIN_PRIO        = 6,
     // MSI mode parameters
-    parameter int unsigned                                          AXI_ADDR_WIDTH  = 64,
-    parameter int unsigned                                          AXI_DATA_WIDTH  = 64,
-    parameter unsigned                                              IMSIC_M_ADDR_TARGET= 64'h24000000,
-    parameter unsigned                                              IMSIC_S_ADDR_TARGET= 64'h28000000,
+    parameter int unsigned                                          AXI_ADDR_WIDTH      = 64,
+    parameter int unsigned                                          AXI_DATA_WIDTH      = 64,
+    parameter unsigned                                              IMSIC_M_ADDR_TARGET = 64'h24000000,
+    parameter unsigned                                              IMSIC_S_ADDR_TARGET = 64'h28000000,
     // DO NOT EDIT BY PARAMETER
     parameter int                                                   NR_BITS_SRC     = (NR_SRC > 32) ? 32 : NR_SRC,
     parameter int                                                   NR_REG          = (NR_SRC-1)/32,
@@ -44,10 +44,10 @@ module aplic_domain_notifier #(
     input   logic [NR_REG:0][NR_BITS_SRC-1:0]                       i_setip_q       ,
     input   logic [NR_REG:0][NR_BITS_SRC-1:0]                       i_setie_q       ,
     input   logic [NR_SRC-1:1][31:0]                                i_target_q      ,
-    input   logic [NR_SRC-1:1]                                      i_intp_domain   ,
+    input   logic [NR_SRC-1:1]                                      i_intp_domain   
     `ifdef DIRECT_MODE
     /** interface for direct mode */
-    input   logic [NR_DOMAINS-1:0][NR_IDCs-1:0][0:0]                i_idelivery     ,
+    ,input  logic [NR_DOMAINS-1:0][NR_IDCs-1:0][0:0]                i_idelivery     ,
     input   logic [NR_DOMAINS-1:0][NR_IDCs-1:0][0:0]                i_iforce        ,
     input   logic [NR_DOMAINS-1:0][NR_IDCs-1:0][IPRIOLEN-1:0]       i_ithreshold    ,
     output  logic [NR_DOMAINS-1:0][NR_IDCs-1:0][25:0]               o_topi_sugg     ,
@@ -55,7 +55,7 @@ module aplic_domain_notifier #(
     output  logic [NR_DOMAINS-1:0][NR_IDCs-1:0]                     o_Xeip_targets  
     `elsif MSI_MODE
     /** interface for MSI mode */
-    input   logic [NR_DOMAINS-1:0][31:0]                            i_genmsi         ,
+    ,input  logic [NR_DOMAINS-1:0][31:0]                            i_genmsi         ,
     output  logic [NR_DOMAINS-1:0]                                  o_genmsi_sent    ,
     output  logic                                                   o_forwarded_valid,
     output  logic [10:0]                                            o_intp_forwd_id  ,

--- a/rtl/aplic/minimal/aplic_domain_top.sv
+++ b/rtl/aplic/minimal/aplic_domain_top.sv
@@ -29,13 +29,13 @@ module aplic_domain_top #(
    input  logic                                 ni_rst           ,
    input  reg_req_t                             i_req_cfg        ,
    output reg_rsp_t                             o_resp_cfg       ,
-   input  logic [NR_SRC-1:0]                    i_irq_sources    ,
+   input  logic [NR_SRC-1:0]                    i_irq_sources    
    /**  interface for direct mode */
    `ifdef DIRECT_MODE
    /** Interrupt Notification to Harts. One per priv. level per hart. */
-   output logic [NR_DOMAINS-1:0][NR_IDCs-1:0]   o_Xeip_targets
+   ,output logic [NR_DOMAINS-1:0][NR_IDCs-1:0]   o_Xeip_targets
    `elsif MSI_MODE
-   output  ariane_axi::req_t                    o_req_msi         ,
+   ,output ariane_axi::req_t                    o_req_msi         ,
    input   ariane_axi::resp_t                   i_resp_msi
    `endif
 );

--- a/rtl/aplic/minimal/aplic_top.sv
+++ b/rtl/aplic/minimal/aplic_top.sv
@@ -27,13 +27,13 @@ module aplic_top #(
    input  logic [NR_SRC-1:0]                    i_irq_sources        ,
    /** APLIC domain interface */
    input  reg_req_t                             i_req_cfg            ,
-   output reg_rsp_t                             o_resp_cfg           ,
+   output reg_rsp_t                             o_resp_cfg           
    /**  interface for direct mode */
    `ifdef DIRECT_MODE
    /** Interrupt Notification to Targets. One per priv. level. */
-   output logic [(NR_DOMAINS*NR_IDCs)-1:0]      o_Xeip_targets
+   ,output logic [(NR_DOMAINS*NR_IDCs)-1:0]      o_Xeip_targets
    `elsif MSI_MODE
-   output  ariane_axi::req_t                    o_req_msi            ,
+   ,output ariane_axi::req_t                    o_req_msi            ,
    input   ariane_axi::resp_t                   i_resp_msi
    `endif
 ); /** End of APLIC top interface */

--- a/rtl/aplic/scalable/aplic_domain_notifier.sv
+++ b/rtl/aplic/scalable/aplic_domain_notifier.sv
@@ -27,7 +27,6 @@ module aplic_domain_notifier #(
     parameter int unsigned                          AXI_ADDR_WIDTH  = 64,
     parameter int unsigned                          AXI_DATA_WIDTH  = 64,
     parameter unsigned                              IMSIC_ADDR_TARGET= 64'h24000000,
-    parameter unsigned                              ID              = 4'b0001,
     // DO NOT EDIT BY PARAMETER
     parameter int                                   NR_BITS_SRC     = (NR_SRC > 32) ? 32 : NR_SRC,
     parameter int                                   NR_REG          = (NR_SRC-1)/32,
@@ -112,9 +111,6 @@ localparam NR_HART_W        = (NR_IDCs == 1) ? 1 : $clog2(NR_IDCs);
     logic                      ready_i;
     logic                      genmsi_sent;
     logic                      axi_busy, axi_busy_q;
-    //logic [3:0]                id_i;
-
-    //assign id_i = ID;
 
     always_comb begin : find_highest_pen_en
         ready_i             = '0;
@@ -157,7 +153,6 @@ localparam NR_HART_W        = (NR_IDCs == 1) ? 1 : $clog2(NR_IDCs);
         .clk_i          ( i_clk             ),
         .rst_ni         ( ni_rst            ),
         .ready_i        ( ready_i           ),
-        //.id_i           ( id_i              ),
         .addr_i         ( addr_i            ),
         .data_i         ( data_i            ),
         .busy_o         ( axi_busy          ),

--- a/rtl/aplic/scalable/aplic_domain_notifier.sv
+++ b/rtl/aplic/scalable/aplic_domain_notifier.sv
@@ -112,9 +112,9 @@ localparam NR_HART_W        = (NR_IDCs == 1) ? 1 : $clog2(NR_IDCs);
     logic                      ready_i;
     logic                      genmsi_sent;
     logic                      axi_busy, axi_busy_q;
-    logic [3:0]                id_i;
+    //logic [3:0]                id_i;
 
-    assign id_i = ID;
+    //assign id_i = ID;
 
     always_comb begin : find_highest_pen_en
         ready_i             = '0;
@@ -157,7 +157,7 @@ localparam NR_HART_W        = (NR_IDCs == 1) ? 1 : $clog2(NR_IDCs);
         .clk_i          ( i_clk             ),
         .rst_ni         ( ni_rst            ),
         .ready_i        ( ready_i           ),
-        .id_i           ( id_i              ),
+        //.id_i           ( id_i              ),
         .addr_i         ( addr_i            ),
         .data_i         ( data_i            ),
         .busy_o         ( axi_busy          ),

--- a/rtl/aplic/scalable/aplic_domain_top.sv
+++ b/rtl/aplic/scalable/aplic_domain_top.sv
@@ -15,7 +15,6 @@ module aplic_domain_top #(
    parameter                               APLIC         = "LEAF",
    parameter                               MODE          = "DIRECT",
    parameter unsigned                      IMSIC_ADDR_TARGET= 64'h24000000,
-   parameter unsigned                      ID            = 4'b0001,
    parameter type                          reg_req_t     = logic,
    parameter type                          reg_rsp_t     = logic,
    // DO NOT EDIT BY PARAMETER
@@ -93,7 +92,6 @@ module aplic_domain_top #(
       .APLIC(APLIC),
       .MODE(MODE),
       .IMSIC_ADDR_TARGET(IMSIC_ADDR_TARGET),
-      .ID(ID)
    ) i_aplic_domain_notifier (
       .i_clk(i_clk),
       .ni_rst(ni_rst),

--- a/rtl/aplic/scalable/aplic_top.sv
+++ b/rtl/aplic/scalable/aplic_top.sv
@@ -121,7 +121,6 @@ aplic_domain_top #(
    .APLIC("NON-LEAF"),
    .MODE(MODE),
    .IMSIC_ADDR_TARGET(64'h24000000),
-   .ID(4'b0001),
    .reg_req_t(reg_req_t),
    .reg_rsp_t(reg_rsp_t)
 ) i_aplic_m_domain_top(
@@ -148,7 +147,6 @@ aplic_domain_top #(
    .APLIC("LEAF"),
    .MODE(MODE),
    .IMSIC_ADDR_TARGET(64'h28000000),
-   .ID(4'b0010),
    .reg_req_t(reg_req_t),
    .reg_rsp_t(reg_rsp_t)
 ) i_aplic_s_domain_top(

--- a/rtl/aplic/scalable/aplic_top.sv
+++ b/rtl/aplic/scalable/aplic_top.sv
@@ -93,18 +93,20 @@ logic                           axi_1_busy;
 
 always_comb begin : basic_interconnect
    if (~axi_1_busy) begin
-      o_req_msi.aw        = axi_req_s_domain.aw ;
-      o_req_msi.aw_valid  = axi_req_s_domain.aw_valid;
-      o_req_msi.w         = axi_req_s_domain.w  ;
-      o_req_msi.w_valid   = axi_req_s_domain.w_valid ;
-      o_req_msi.b_ready   = axi_req_s_domain.b_ready ;
+      o_req_msi.aw               = axi_req_s_domain.aw ;
+      o_req_msi.aw_valid         = axi_req_s_domain.aw_valid;
+      o_req_msi.w                = axi_req_s_domain.w  ;
+      o_req_msi.w_valid          = axi_req_s_domain.w_valid ;
+      o_req_msi.b_ready          = axi_req_s_domain.b_ready ;
       axi_resp_s_domain.w_ready  = i_resp_msi.w_ready;
+      axi_resp_m_domain.w_ready  = 'h0;
    end else begin
-      o_reqo_req_msi.aw        = axi_req_m_domain.aw ;
-      o_reqo_req_msi.aw_valid  = axi_req_m_domain.aw_valid;
-      o_reqo_req_msi.w         = axi_req_m_domain.w  ;
-      o_reqo_req_msi.w_valid   = axi_req_m_domain.w_valid ;
-      o_reqo_req_msi.b_ready   = axi_req_m_domain.b_ready ;
+      axi_resp_s_domain.w_ready  = 'h0;
+      o_req_msi.aw               = axi_req_m_domain.aw ;
+      o_req_msi.aw_valid         = axi_req_m_domain.aw_valid;
+      o_req_msi.w                = axi_req_m_domain.w  ;
+      o_req_msi.w_valid          = axi_req_m_domain.w_valid ;
+      o_req_msi.b_ready          = axi_req_m_domain.b_ready ;
       axi_resp_m_domain.w_ready  = i_resp_msi.w_ready;
    end
 end

--- a/test/aplic-imsic/Makefile
+++ b/test/aplic-imsic/Makefile
@@ -9,7 +9,7 @@ CLEAN =
 
 # defaults
 SIM ?= verilator
-EXTRA_ARGS += --trace --trace-structs
+EXTRA_ARGS += --trace --trace-structs -Wno-LATCH
 TOPLEVEL_LANG ?= verilog
 
 AXI_FOLDER = $(PWD)/../../vendor/
@@ -21,16 +21,16 @@ VERILOG_SOURCES += $(AXI_FOLDER)axi_pkg.sv
 VERILOG_SOURCES += $(AXI_FOLDER)ariane_axi_pkg.sv
 VERILOG_SOURCES += $(AXI_FOLDER)axi_lite_slave.sv
 
-VERILOG_SOURCES += $(SRC_FOLDER)/aplic_defines.svh
-VERILOG_SOURCES += $(SRC_FOLDER)/axi4_lite_write_master.sv
-VERILOG_SOURCES += $(SRC_FOLDER)/aplic_regmap.sv
-VERILOG_SOURCES += $(SRC_FOLDER)/aplic_domain_notifier.sv
-VERILOG_SOURCES += $(SRC_FOLDER)/aplic_domain_regctl.sv
-VERILOG_SOURCES += $(SRC_FOLDER)/aplic_domain_gateway.sv
-VERILOG_SOURCES += $(SRC_FOLDER)/aplic_domain_top.sv
-VERILOG_SOURCES += $(SRC_FOLDER)/aplic_top.sv
-VERILOG_SOURCES += $(SRC_FOLDER)/imsic_regmap.sv
-VERILOG_SOURCES += $(SRC_FOLDER)/imsic_top.sv
+VERILOG_SOURCES += $(SRC_FOLDER)/aplic/common/aplic_defines.svh
+VERILOG_SOURCES += $(SRC_FOLDER)/aplic/common/axi4_lite_write_master.sv
+VERILOG_SOURCES += $(SRC_FOLDER)/aplic/scalable/aplic_regmap.sv
+VERILOG_SOURCES += $(SRC_FOLDER)/aplic/scalable/aplic_domain_notifier.sv
+VERILOG_SOURCES += $(SRC_FOLDER)/aplic/scalable/aplic_domain_regctl.sv
+VERILOG_SOURCES += $(SRC_FOLDER)/aplic/scalable/aplic_domain_gateway.sv
+VERILOG_SOURCES += $(SRC_FOLDER)/aplic/scalable/aplic_domain_top.sv
+VERILOG_SOURCES += $(SRC_FOLDER)/aplic/scalable/aplic_top.sv
+VERILOG_SOURCES += $(SRC_FOLDER)/imsic/imsic_regmap.sv
+VERILOG_SOURCES += $(SRC_FOLDER)/imsic/imsic_top.sv
 VERILOG_SOURCES += $(TEST_FOLDER)./wrap.sv
 
 # TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file

--- a/test/aplic-imsic/wrap.sv
+++ b/test/aplic-imsic/wrap.sv
@@ -41,9 +41,9 @@ module aplic_imsic_top_wrapper #(
     output  logic [31:0]                    reg_intf_resp_d32_rdata,
     output  logic                           reg_intf_resp_d32_error,
     output  logic                           reg_intf_resp_d32_ready,
-    input   logic [NR_SRC-1:0]              i_irq_sources,
+    input   logic [NR_SRC-1:0]              i_irq_sources
 `ifdef MSI_MODE
-    output  logic [NR_INTP_FILES-1:0]       o_Xeip_targets
+    ,output  logic [NR_INTP_FILES-1:0]       o_Xeip_targets
 `endif
 );
 
@@ -83,8 +83,8 @@ assign reg_intf_resp_d32_ready              = o_resp.ready;
         .i_req_cfg          ( i_req                         ),
         .o_resp_cfg         ( o_resp                        ),
         .i_irq_sources      ( i_irq_sources                 ),
-        .o_req              ( master_req                    ),
-        .i_resp             ( master_resp                   )
+        .o_req_msi          ( master_req                    ),
+        .i_resp_msi         ( master_resp                   )
     );
 
     imsic_top #(

--- a/test/aplic/Notifier/Makefile
+++ b/test/aplic/Notifier/Makefile
@@ -21,9 +21,9 @@ VERILOG_SOURCES += $(AXI_FOLDER)reg_intf_pkg.sv
 VERILOG_SOURCES += $(AXI_FOLDER)axi_pkg.sv
 VERILOG_SOURCES += $(AXI_FOLDER)ariane_axi_pkg.sv
 
-VERILOG_SOURCES += $(SRC_FOLDER)/aplic_defines.svh
-VERILOG_SOURCES += $(SRC_FOLDER)/axi4_lite_write_master.sv
-VERILOG_SOURCES += $(SRC_FOLDER)/aplic_domain_notifier.sv
+VERILOG_SOURCES += $(SRC_FOLDER)/aplic/common/aplic_defines.svh
+VERILOG_SOURCES += $(SRC_FOLDER)/aplic/common/axi4_lite_write_master.sv
+VERILOG_SOURCES += $(SRC_FOLDER)/aplic/scalable/aplic_domain_notifier.sv
 VERILOG_SOURCES += $(WRAPPER_SRC)
 
 # TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file

--- a/test/imsic/Makefile
+++ b/test/imsic/Makefile
@@ -19,9 +19,9 @@ VERILOG_SOURCES += $(AXI_FOLDER)axi_pkg.sv
 VERILOG_SOURCES += $(AXI_FOLDER)ariane_axi_pkg.sv
 VERILOG_SOURCES += $(AXI_FOLDER)axi_lite_slave.sv
 
-VERILOG_SOURCES += $(SRC_FOLDER)/imsic_top.sv
-VERILOG_SOURCES += $(SRC_FOLDER)/imsic_regmap.sv
-VERILOG_SOURCES += $(SRC_FOLDER)/axi4_lite_write_master.sv
+VERILOG_SOURCES += $(SRC_FOLDER)/imsic/imsic_top.sv
+VERILOG_SOURCES += $(SRC_FOLDER)/imsic/imsic_regmap.sv
+VERILOG_SOURCES += $(SRC_FOLDER)/aplic/common/axi4_lite_write_master.sv
 VERILOG_SOURCES += $(TEST_FOLDER)./wrap.sv
 
 # TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file

--- a/test/imsic/wrap.sv
+++ b/test/imsic/wrap.sv
@@ -45,7 +45,6 @@ axi_lite_write_master#(
     .clk_i              ( i_clk             ),
     .rst_ni             ( ni_rst            ),
     .ready_i            ( ready_i           ),
-    .id_i               ( '0                ),
     .busy_o             (                   ),
     .addr_i             ( addr_i            ),
     .data_i             ( data_i            ),


### PR DESCRIPTION
This PR includes several fixes related to syntax, typos, and latch errors for Verilator v5.006. Additionally, the PR has only been tested for the configuration for aplic(scalable) with MSI mode.